### PR TITLE
New functionality

### DIFF
--- a/android/src/main/java/eu/sndr/fluttermdnsplugin/FlutterMdnsPlugin.java
+++ b/android/src/main/java/eu/sndr/fluttermdnsplugin/FlutterMdnsPlugin.java
@@ -160,8 +160,10 @@ public class FlutterMdnsPlugin implements MethodCallHandler {
     map.put("name", info.getServiceName() != null ? info.getServiceName() : "");
 
     map.put("type", info.getServiceType() != null ? info.getServiceType() : "");
-
-    map.put("host", info.getHost() != null ? info.getHost().toString() : "");
+    
+    map.put("hostName", info.getHost() != null ? info.getHost().getHostName() : "");
+    
+    map.put("address", info.getHost() != null ? info.getHost().getHostAddress() : "");
 
     map.put("port", info.getPort());
 

--- a/android/src/main/java/eu/sndr/fluttermdnsplugin/FlutterMdnsPlugin.java
+++ b/android/src/main/java/eu/sndr/fluttermdnsplugin/FlutterMdnsPlugin.java
@@ -119,8 +119,22 @@ public class FlutterMdnsPlugin implements MethodCallHandler {
 
         mNsdManager.resolveService(nsdServiceInfo, new NsdManager.ResolveListener() {
           @Override
-          public void onResolveFailed(NsdServiceInfo nsdServiceInfo, int i) {
+          public void onResolveFailed(NsdServiceInfo nsdServiceInfo, int errorCode) {
             Log.d(TAG, "Failed to resolve service : " + nsdServiceInfo.toString());
+
+            switch (errorCode) {
+              case NsdManager.FAILURE_ALREADY_ACTIVE:
+                  Log.e(TAG, "FAILURE_ALREADY_ACTIVE");
+                  // Just try again...
+                  onServiceFound(nsdServiceInfo);
+                  break;
+              case NsdManager.FAILURE_INTERNAL_ERROR:
+                  Log.e(TAG, "FAILURE_INTERNAL_ERROR");
+                  break;
+              case NsdManager.FAILURE_MAX_LIMIT:
+                  Log.e(TAG, "FAILURE_MAX_LIMIT");
+                  break;
+            }
           }
 
           @Override

--- a/android/src/main/java/eu/sndr/fluttermdnsplugin/FlutterMdnsPlugin.java
+++ b/android/src/main/java/eu/sndr/fluttermdnsplugin/FlutterMdnsPlugin.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Collections;
 
 import eu.sndr.fluttermdnsplugin.handlers.DiscoveryRunningHandler;
 import eu.sndr.fluttermdnsplugin.handlers.ServiceDiscoveredHandler;
@@ -178,7 +179,7 @@ public class FlutterMdnsPlugin implements MethodCallHandler {
   private static Map<String, Object> ServiceToMap(NsdServiceInfo info) {
     Map<String, Object> map = new HashMap<>();
 
-    map.put("attr", info.getAttributes() != null ? info.getAttributes() : "");
+    map.put("attr", info.getAttributes() != null ? info.getAttributes() : Collections.emptyMap());
 
     map.put("name", info.getServiceName() != null ? info.getServiceName() : "");
 

--- a/android/src/main/java/eu/sndr/fluttermdnsplugin/FlutterMdnsPlugin.java
+++ b/android/src/main/java/eu/sndr/fluttermdnsplugin/FlutterMdnsPlugin.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import eu.sndr.fluttermdnsplugin.handlers.DiscoveryRunningHandler;
 import eu.sndr.fluttermdnsplugin.handlers.ServiceDiscoveredHandler;
 import eu.sndr.fluttermdnsplugin.handlers.ServiceResolvedHandler;
+import eu.sndr.fluttermdnsplugin.handlers.ServiceLostHandler;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -48,6 +49,10 @@ public class FlutterMdnsPlugin implements MethodCallHandler {
     mResolvedHandler = new ServiceResolvedHandler();
     serviceResolved.setStreamHandler(mResolvedHandler);
 
+    EventChannel serviceLost = new EventChannel(r.messenger(), NAMESPACE + "/lost");
+    mLostHandler = new ServiceLostHandler();
+    serviceLost.setStreamHandler(mLostHandler);
+
     EventChannel discoveryRunning = new EventChannel(r.messenger(), NAMESPACE + "/running");
     mDiscoveryRunningHandler = new DiscoveryRunningHandler();
     discoveryRunning.setStreamHandler(mDiscoveryRunningHandler);
@@ -59,6 +64,7 @@ public class FlutterMdnsPlugin implements MethodCallHandler {
   private DiscoveryRunningHandler mDiscoveryRunningHandler;
   private ServiceDiscoveredHandler mDiscoveredHandler;
   private ServiceResolvedHandler mResolvedHandler;
+  private ServiceLostHandler mLostHandler;
 
   @Override
   public void onMethodCall(MethodCall call, Result result) {
@@ -147,6 +153,7 @@ public class FlutterMdnsPlugin implements MethodCallHandler {
       @Override
       public void onServiceLost(NsdServiceInfo nsdServiceInfo) {
         Log.d(TAG, "Lost Service : " + nsdServiceInfo.toString());
+        mLostHandler.onServiceLost(ServiceToMap(nsdServiceInfo));
       }
     };
 

--- a/android/src/main/java/eu/sndr/fluttermdnsplugin/FlutterMdnsPlugin.java
+++ b/android/src/main/java/eu/sndr/fluttermdnsplugin/FlutterMdnsPlugin.java
@@ -157,12 +157,14 @@ public class FlutterMdnsPlugin implements MethodCallHandler {
   private static Map<String, Object> ServiceToMap(NsdServiceInfo info) {
     Map<String, Object> map = new HashMap<>();
 
+    map.put("attr", info.getAttributes() != null ? info.getAttributes() : "");
+
     map.put("name", info.getServiceName() != null ? info.getServiceName() : "");
 
     map.put("type", info.getServiceType() != null ? info.getServiceType() : "");
-    
+
     map.put("hostName", info.getHost() != null ? info.getHost().getHostName() : "");
-    
+
     map.put("address", info.getHost() != null ? info.getHost().getHostAddress() : "");
 
     map.put("port", info.getPort());

--- a/android/src/main/java/eu/sndr/fluttermdnsplugin/handlers/ServiceLostHandler.java
+++ b/android/src/main/java/eu/sndr/fluttermdnsplugin/handlers/ServiceLostHandler.java
@@ -1,0 +1,23 @@
+package eu.sndr.fluttermdnsplugin.handlers;
+
+import java.util.Map;
+
+import io.flutter.plugin.common.EventChannel;
+
+public class ServiceLostHandler implements EventChannel.StreamHandler {
+
+    EventChannel.EventSink sink;
+    @Override
+    public void onListen(Object o, EventChannel.EventSink eventSink) {
+        sink = eventSink;
+    }
+
+    @Override
+    public void onCancel(Object o) {
+
+    }
+
+    public void onServiceLost(Map<String, Object> serviceInfoMap){
+        sink.success(serviceInfoMap);
+    }
+}

--- a/ios/Classes/FlutterMdnsPlugin.m
+++ b/ios/Classes/FlutterMdnsPlugin.m
@@ -164,7 +164,7 @@
     return @{
             @"name": nil == [aNetService name] ? @"" : [aNetService name],
             @"type": nil == [aNetService type] ? @"" : [aNetService type],
-            @"hostName": nil == [aNetService type] ? @"" : [aNetService type],
+            @"hostName": nil == [aNetService hostName] ? @"" : [aNetService hostName],
             @"address": nil == address ? @"" : address,
             @"port": @([aNetService port])
     };

--- a/ios/Classes/FlutterMdnsPlugin.m
+++ b/ios/Classes/FlutterMdnsPlugin.m
@@ -161,7 +161,10 @@
 }
 
 - (NSDictionary *) serviceToDictionary:(NSNetService *)aNetService withAddress:(NSString *)address  {
+    NSData* data = [aNetService TXTRecordData];
+    NSDictionary* dict = [NSNetService dictionaryFromTXTRecordData:data];
     return @{
+            @"attr": nil == dict ? @"" : dict,
             @"name": nil == [aNetService name] ? @"" : [aNetService name],
             @"type": nil == [aNetService type] ? @"" : [aNetService type],
             @"hostName": nil == [aNetService hostName] ? @"" : [aNetService hostName],

--- a/ios/Classes/FlutterMdnsPlugin.m
+++ b/ios/Classes/FlutterMdnsPlugin.m
@@ -164,7 +164,8 @@
     return @{
             @"name": nil == [aNetService name] ? @"" : [aNetService name],
             @"type": nil == [aNetService type] ? @"" : [aNetService type],
-            @"host": nil == address ? @"" : address,
+            @"hostName": nil == [aNetService type] ? @"" : [aNetService type],
+            @"address": nil == address ? @"" : address,
             @"port": @([aNetService port])
     };
 }

--- a/ios/Classes/FlutterMdnsPlugin.m
+++ b/ios/Classes/FlutterMdnsPlugin.m
@@ -177,7 +177,7 @@
     NSData* data = [aNetService TXTRecordData];
     NSDictionary* dict = [NSNetService dictionaryFromTXTRecordData:data];
     return @{
-            @"attr": nil == dict ? @"" : dict,
+            @"attr": nil == dict ? [NSMutableDictionary dictionary] : dict,
             @"name": nil == [aNetService name] ? @"" : [aNetService name],
             @"type": nil == [aNetService type] ? @"" : [aNetService type],
             @"hostName": nil == [aNetService hostName] ? @"" : [aNetService hostName],

--- a/ios/Classes/ServiceLostHandler.h
+++ b/ios/Classes/ServiceLostHandler.h
@@ -1,0 +1,12 @@
+//
+// Created by brouwer on 23-11-18.
+//
+
+#import <Foundation/Foundation.h>
+#import <Flutter/Flutter.h>
+
+@interface ServiceLostHandler : NSObject <FlutterStreamHandler>
+- (void)onServiceLost:(NSDictionary *)serviceInfoMap;
+
+- (BOOL)isReady;
+@end

--- a/ios/Classes/ServiceLostHandler.m
+++ b/ios/Classes/ServiceLostHandler.m
@@ -1,0 +1,28 @@
+//
+// Created by brouwer on 23-11-18.
+//
+
+#import "ServiceLostHandler.h"
+
+@implementation ServiceLostHandler {
+    FlutterEventSink _eventSink;
+}
+
+- (FlutterError *_Nullable)onListenWithArguments:(id _Nullable)arguments eventSink:(FlutterEventSink)events {
+    _eventSink = events;
+    return nil;
+}
+
+- (FlutterError *_Nullable)onCancelWithArguments:(id _Nullable)arguments {
+    return nil;
+}
+
+- (void) onServiceLost:(NSDictionary *)serviceInfoMap {
+    _eventSink(serviceInfoMap);
+}
+
+- (BOOL) isReady {
+    return nil != _eventSink;
+}
+
+@end

--- a/lib/flutter_mdns_plugin.dart
+++ b/lib/flutter_mdns_plugin.dart
@@ -19,7 +19,7 @@ class ServiceInfo{
     int port = 0;
 
     if (fromChannel.containsKey("attr") ) {
-      attr = fromChannel["attr"];
+      attr = Map<String, Uint8List>.from(fromChannel["attr"]);
     }
 
     if (fromChannel.containsKey("name") ) {

--- a/lib/flutter_mdns_plugin.dart
+++ b/lib/flutter_mdns_plugin.dart
@@ -1,19 +1,28 @@
+import 'dart:typed_data';
 import 'package:flutter/services.dart';
 
 class ServiceInfo{
+  Map<String, Uint8List> attr;
   String name;
   String type;
-  String host;
+  String hostName;
+  String address;
   int port;
-  ServiceInfo(this.name, this.type, this.host, this.port);
+  ServiceInfo(this.attr, this.name, this.type, this.hostName, this.address, this.port);
 
   static ServiceInfo fromMap(Map fromChannel){
+    Map<String, Uint8List> attr;
     String name = "";
     String type = "";
-    String host = "";
+    String hostName = "";
+    String address = "";
     int port = 0;
 
-    if ( fromChannel.containsKey("name") ) {
+    if (fromChannel.containsKey("attr") ) {
+      attr = fromChannel["attr"];
+    }
+
+    if (fromChannel.containsKey("name") ) {
       name = fromChannel["name"];
     }
 
@@ -21,20 +30,24 @@ class ServiceInfo{
       type = fromChannel["type"];
     }
 
-    if (fromChannel.containsKey("host")) {
-      host = fromChannel["host"];
+    if (fromChannel.containsKey("hostName")) {
+      hostName = fromChannel["hostName"];
+    }
+
+    if (fromChannel.containsKey("address")) {
+      address = fromChannel["address"];
     }
 
     if (fromChannel.containsKey("port")) {
       port = fromChannel["port"];
     }
 
-    return new ServiceInfo(name, type, host, port);
+    return new ServiceInfo(attr, name, type, hostName, address, port);
   }
 
   @override
   String toString(){
-    return "Name: $name, Type: $type, Host: $host, Port: $port";
+    return "Name: $name, Type: $type, HostName: $hostName, Address: $address, Port: $port";
   }
 }
 typedef void ServiceInfoCallback(ServiceInfo info);

--- a/lib/flutter_mdns_plugin.dart
+++ b/lib/flutter_mdns_plugin.dart
@@ -60,11 +60,13 @@ class DiscoveryCallbacks{
   VoidCallback onDiscoveryStopped;
   ServiceInfoCallback onDiscovered;
   ServiceInfoCallback onResolved;
+  ServiceInfoCallback onLost;
   DiscoveryCallbacks({
     this.onDiscoveryStarted,
     this.onDiscoveryStopped,
     this.onDiscovered,
     this.onResolved,
+    this.onLost,
   });
 }
 
@@ -79,6 +81,9 @@ class FlutterMdnsPlugin {
 
   final EventChannel _serviceResolvedChannel =
   const EventChannel("$NAMESPACE/resolved");
+
+  final EventChannel _serviceLostChannel =
+  const EventChannel("$NAMESPACE/lost");
 
   final EventChannel _discoveryRunningChannel =
   const EventChannel("$NAMESPACE/running");
@@ -97,6 +102,11 @@ class FlutterMdnsPlugin {
       _serviceDiscoveredChannel.receiveBroadcastStream().listen((data) {
         print("Service discovered ${data.toString()}");
         discoveryCallbacks.onDiscovered(ServiceInfo.fromMap(data));
+      });
+
+      _serviceLostChannel.receiveBroadcastStream().listen((data) {
+        print("Service lost ${data.toString()}");
+        discoveryCallbacks.onLost(ServiceInfo.fromMap(data));
       });
 
       _discoveryRunningChannel.receiveBroadcastStream().listen((running) {

--- a/lib/flutter_mdns_plugin.dart
+++ b/lib/flutter_mdns_plugin.dart
@@ -8,6 +8,7 @@ class ServiceInfo{
   ServiceInfo(this.name, this.type, this.host, this.port);
 
   static ServiceInfo fromMap(Map fromChannel){
+    print (fromChannel);
     String name = "";
     String type = "";
     String host = "";

--- a/lib/flutter_mdns_plugin.dart
+++ b/lib/flutter_mdns_plugin.dart
@@ -8,7 +8,6 @@ class ServiceInfo{
   ServiceInfo(this.name, this.type, this.host, this.port);
 
   static ServiceInfo fromMap(Map fromChannel){
-    print (fromChannel);
     String name = "";
     String type = "";
     String host = "";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,11 @@
 name: flutter_mdns_plugin
-description: A new flutter plugin project.
+description: Flutter mDNS plugin
 version: 0.0.1
 author:
 homepage:
+
+environment:
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
I forked your project to make some changes, and figured this might be interesting to others as well. Sorry for the terrible commit messages. 

- Changed `host` to `address`, this one breaks backward compatibility, I feel it is more correct so I am using this one, but can change it back for the PR. 
- Added `hostName` property (works only on iOS)
- Added TXT records from discovered services in a property called `attr`
- On Android only 1 service can be resolved at a time, if you rapidly resolve multiple services in succession it throws a FAILURE_ALREADY_ACTIVE error, I fixed this by simply calling onServiceFound again if such an error is thrown, it might loop a few times but eventually all services resolve on Android as well. Ran into this when testing on both iOS and Android, and Android always only returned 1 service, whereas iOS would show all. 
- Added callbacks for when a service is lost/removed from mDNS