### PR TITLE
handler+looper+runnable for method and event channels. Fixes UiThread…

### DIFF
--- a/android/src/main/java/eu/sndr/fluttermdnsplugin/handlers/DiscoveryRunningHandler.java
+++ b/android/src/main/java/eu/sndr/fluttermdnsplugin/handlers/DiscoveryRunningHandler.java
@@ -1,9 +1,13 @@
 package eu.sndr.fluttermdnsplugin.handlers;
 
 import io.flutter.plugin.common.EventChannel;
+import android.os.Handler;
+import android.os.Looper;
 
 public class DiscoveryRunningHandler implements EventChannel.StreamHandler {
     EventChannel.EventSink sink;
+    private Handler handler;
+
     @Override
     public void onListen(Object o, EventChannel.EventSink eventSink) {
         sink = eventSink;
@@ -15,10 +19,22 @@ public class DiscoveryRunningHandler implements EventChannel.StreamHandler {
     }
 
     public void onDiscoveryStopped(){
-        sink.success(false);
+        handler = new Handler(Looper.getMainLooper());
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                sink.success(true);
+            }
+        });
     }
 
     public void onDiscoveryStarted(){
-        sink.success(true);
+        handler = new Handler(Looper.getMainLooper());
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                sink.success(true);
+            }
+        });
     }
 }

--- a/android/src/main/java/eu/sndr/fluttermdnsplugin/handlers/ServiceDiscoveredHandler.java
+++ b/android/src/main/java/eu/sndr/fluttermdnsplugin/handlers/ServiceDiscoveredHandler.java
@@ -3,10 +3,15 @@ package eu.sndr.fluttermdnsplugin.handlers;
 import java.util.Map;
 
 import io.flutter.plugin.common.EventChannel;
+import android.os.Handler;
+import android.os.Looper;
 
 public class ServiceDiscoveredHandler implements EventChannel.StreamHandler {
 
     EventChannel.EventSink sink;
+    private Handler handler;
+    Map<String, Object> serviceInfoMap;
+
     @Override
     public void onListen(Object o, EventChannel.EventSink eventSink) {
         sink = eventSink;
@@ -17,7 +22,14 @@ public class ServiceDiscoveredHandler implements EventChannel.StreamHandler {
 
     }
 
-    public void onServiceDiscovered(Map<String, Object> serviceInfoMap){
-        sink.success(serviceInfoMap);
+    public void onServiceDiscovered(Map<String, Object> serviceInfoMapGot){
+        serviceInfoMap = serviceInfoMapGot;
+        handler = new Handler(Looper.getMainLooper());
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                sink.success(serviceInfoMap);
+            }
+        });
     }
 }

--- a/android/src/main/java/eu/sndr/fluttermdnsplugin/handlers/ServiceLostHandler.java
+++ b/android/src/main/java/eu/sndr/fluttermdnsplugin/handlers/ServiceLostHandler.java
@@ -1,12 +1,16 @@
 package eu.sndr.fluttermdnsplugin.handlers;
 
 import java.util.Map;
+import android.os.Handler;
+import android.os.Looper;
 
 import io.flutter.plugin.common.EventChannel;
 
 public class ServiceLostHandler implements EventChannel.StreamHandler {
 
     EventChannel.EventSink sink;
+    private Handler handler;
+    Map<String, Object> serviceInfoMap;
     @Override
     public void onListen(Object o, EventChannel.EventSink eventSink) {
         sink = eventSink;
@@ -17,7 +21,14 @@ public class ServiceLostHandler implements EventChannel.StreamHandler {
 
     }
 
-    public void onServiceLost(Map<String, Object> serviceInfoMap){
-        sink.success(serviceInfoMap);
+    public void onServiceLost(Map<String, Object> serviceInfoMapGot){
+        serviceInfoMap = serviceInfoMapGot;
+        handler = new Handler(Looper.getMainLooper());
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                sink.success(serviceInfoMap);
+            }
+        });
     }
 }

--- a/android/src/main/java/eu/sndr/fluttermdnsplugin/handlers/ServiceResolvedHandler.java
+++ b/android/src/main/java/eu/sndr/fluttermdnsplugin/handlers/ServiceResolvedHandler.java
@@ -3,10 +3,16 @@ package eu.sndr.fluttermdnsplugin.handlers;
 import java.util.Map;
 
 import io.flutter.plugin.common.EventChannel;
+import android.os.Handler;
+import android.os.Looper;
 
 public class ServiceResolvedHandler implements EventChannel.StreamHandler {
 
+
+
     EventChannel.EventSink sink;
+    private Handler handler;
+    Map<String, Object> serviceInfoMap;
     @Override
     public void onListen(Object o, EventChannel.EventSink eventSink) {
         sink = eventSink;
@@ -17,8 +23,15 @@ public class ServiceResolvedHandler implements EventChannel.StreamHandler {
 
     }
 
-    public void onServiceResolved(Map<String, Object> serviceInfoMap) {
-        sink.success(serviceInfoMap);
+    public void onServiceResolved(Map<String, Object> serviceInfoMapGot) {
+        serviceInfoMap = serviceInfoMapGot;
+        handler = new Handler(Looper.getMainLooper());
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                sink.success(serviceInfoMap);
+            }
+        });
     }
 
 }


### PR DESCRIPTION
Flutter now forces method and event calls to be on a UiThread. It's after Flutter 1.5 not sure which version but it is on the stable release.

java.lang.RuntimeException: Methods marked with @UiThread must be executed on the main thread. 

I'm not an Android developer so please feel free to edit this if you want to pull it.

P.s. thank you for this plugin, using it in a flutter production app and working really well.