### PR TITLE
Acquire MulticastLock to fix mDNS discovery on Google Pixel phones

### DIFF
--- a/android/src/main/java/eu/sndr/fluttermdnsplugin/FlutterMdnsPlugin.java
+++ b/android/src/main/java/eu/sndr/fluttermdnsplugin/FlutterMdnsPlugin.java
@@ -61,7 +61,7 @@ public class FlutterMdnsPlugin implements MethodCallHandler {
     serviceLost.setStreamHandler(mLostHandler);
 
     EventChannel discoveryRunning = new EventChannel(r.messenger(), NAMESPACE + "/running");
-    mDiscoveryRunningHandler = new DiscoveryRunningHandler();
+    mDiscoveryRunningHandler = new DiscoveryRunningHandler(r.activity());
     discoveryRunning.setStreamHandler(mDiscoveryRunningHandler);
 
     mRegistrar = r;


### PR DESCRIPTION
This fixes problem with discovery not working reliably on Google Pixel phones.

(See https://stackoverflow.com/questions/53615125/nsdmanager-discovery-does-not-work-on-android-9)