### PR TITLE
Fix for android NsdManager: MulticastLock under-locked multicastLock

### DIFF
--- a/android/src/main/java/eu/sndr/fluttermdnsplugin/handlers/DiscoveryRunningHandler.java
+++ b/android/src/main/java/eu/sndr/fluttermdnsplugin/handlers/DiscoveryRunningHandler.java
@@ -32,8 +32,12 @@ public class DiscoveryRunningHandler implements EventChannel.StreamHandler {
     }
 
     public void onDiscoveryStopped(){
-        multicastLock.release();
-        handler.post(() -> sink.success(false));
+        if (multicastLock.isHeld()) {
+            //This is the fix for android crash 'NsdManager MulticastLock under-locked multicastLock'.
+            //https://stackoverflow.com/a/14949367/468952
+            multicastLock.release();
+            handler.post(() -> sink.success(false));
+        }
     }
 
     public void onDiscoveryStarted(){


### PR DESCRIPTION
While working with flutter application, facing the random crash in android version. Identified the root cause and solution from the stackoverflow discussions as mentioned in the below link. Verified the solution and it works great. Would like to see this in official release of the flutter_mdns_plugin package.

Issue reproducibility steps: 
Multiple calls to the startDiscovery method.

Solution source:
https://stackoverflow.com/a/14949367/468952

Tested environment:
Flutter 2.2.1 • channel stable
Dart 2.13.1
dart_chromecast: ^0.2.5
Android OS: 10
Phone model: Galaxy S10 [SM-G973F]

Error logs in android:
E/AndroidRuntime(10918): FATAL EXCEPTION: NsdManager
E/AndroidRuntime(10918): Process: com.kpn.magicx.pca_app, PID: 10918
E/AndroidRuntime(10918): java.lang.RuntimeException: MulticastLock under-locked multicastLock
E/AndroidRuntime(10918): 	at android.net.wifi.WifiManager$MulticastLock.release(WifiManager.java:5738)
E/AndroidRuntime(10918): 	at eu.sndr.fluttermdnsplugin.handlers.DiscoveryRunningHandler.onDiscoveryStopped(DiscoveryRunningHandler.java:35)
E/AndroidRuntime(10918): 	at eu.sndr.fluttermdnsplugin.FlutterMdnsPlugin$1.onStartDiscoveryFailed(FlutterMdnsPlugin.java:112)
E/AndroidRuntime(10918): 	at android.net.nsd.NsdManager$ServiceHandler.handleMessage(NsdManager.java:383)
E/AndroidRuntime(10918): 	at android.os.Handler.dispatchMessage(Handler.java:107)
E/AndroidRuntime(10918): 	at android.os.Looper.loop(Looper.java:237)
E/AndroidRuntime(10918): 	at android.os.HandlerThread.run(HandlerThread.java:67)